### PR TITLE
refactor: [gui] titlebar, panel and shortcuts

### DIFF
--- a/include/dfm-gui/applet.h
+++ b/include/dfm-gui/applet.h
@@ -73,8 +73,8 @@ protected:
     QScopedPointer<AppletPrivate> dptr;
 
 private:
-    Q_DECLARE_PRIVATE_D(dptr, Applet);
-    Q_DISABLE_COPY(Applet);
+    Q_DECLARE_PRIVATE_D(dptr, Applet)
+    Q_DISABLE_COPY(Applet)
 
     friend class AppletItem;
     friend class ContainmentItem;

--- a/include/dfm-gui/appletitem.h
+++ b/include/dfm-gui/appletitem.h
@@ -32,8 +32,8 @@ public:
 
 private:
     QScopedPointer<AppletItemPrivate> dptr;
-    Q_DECLARE_PRIVATE_D(dptr, AppletItem);
-    Q_DISABLE_COPY(AppletItem);
+    Q_DECLARE_PRIVATE_D(dptr, AppletItem)
+    Q_DISABLE_COPY(AppletItem)
 };
 
 DFMGUI_END_NAMESPACE

--- a/include/dfm-gui/panel.h
+++ b/include/dfm-gui/panel.h
@@ -6,12 +6,15 @@
 #define PANEL_H
 
 #include <dfm-gui/containment.h>
+#include <dfm-gui/quickutils.h>
 
 #include <QObject>
 
 class QQuickWindow;
 
 DFMGUI_BEGIN_NAMESPACE
+
+class AppletItem;
 
 // TODO:此部分是否和 Applet 分离，而非继承关系
 class PanelPrivate;
@@ -31,15 +34,16 @@ public:
     void setShowSidebar(bool b);
     Q_SIGNAL void showSidebarChanged(bool show);
 
-    void installTitleBar(Applet *titlebar);
-    void installSideBar(Applet *sidebar);
-    void installWorkSpace(Applet *workspace);
-    void installDetailView(Applet *detailview);
+    // TODO: 是否沿用之前框架的注册方式
+    Q_INVOKABLE void installTitleBar(AppletItem *titlebar);
+    Q_INVOKABLE void installSideBar(AppletItem *sidebar);
+    Q_INVOKABLE void installWorkSpace(AppletItem *workspace);
+    Q_INVOKABLE void installDetailView(AppletItem *detailview);
 
-    Applet *titleBar() const;
-    Applet *sideBar() const;
-    Applet *workSpace() const;
-    Applet *detailView() const;
+    AppletItem *titleBar() const;
+    AppletItem *sideBar() const;
+    AppletItem *workSpace() const;
+    AppletItem *detailView() const;
 
     virtual void loadState();
     virtual void saveState();
@@ -51,14 +55,19 @@ Q_SIGNALS:
     void aboutToOpen();
     void aboutToClose();
 
+    void shortcutTriggered(QuickUtils::ShortcutType type, const QKeyCombination &combin);
+
     void titleBarInstallFinished();
     void sideBarInstallFinished();
     void workspaceInstallFinished();
     void detailViewInstallFinished();
 
+protected:
+    bool eventFilter(QObject *object, QEvent *event) override;
+
 private:
-    Q_DECLARE_PRIVATE_D(dptr, Panel);
-    Q_DISABLE_COPY(Panel);
+    Q_DECLARE_PRIVATE_D(dptr, Panel)
+    Q_DISABLE_COPY(Panel)
 };
 
 DFMGUI_END_NAMESPACE

--- a/include/dfm-gui/panel.h
+++ b/include/dfm-gui/panel.h
@@ -19,18 +19,42 @@ class Panel : public Containment
 {
     Q_OBJECT
 
+    Q_PROPERTY(bool showSidebar READ showSidebar WRITE setShowSidebar NOTIFY showSidebarChanged FINAL)
+
 public:
     explicit Panel(QObject *parent = nullptr);
 
     QQuickWindow *window() const;
     quint64 windId() const;
 
+    bool showSidebar() const;
+    void setShowSidebar(bool b);
+    Q_SIGNAL void showSidebarChanged(bool show);
+
+    void installTitleBar(Applet *titlebar);
+    void installSideBar(Applet *sidebar);
+    void installWorkSpace(Applet *workspace);
+    void installDetailView(Applet *detailview);
+
+    Applet *titleBar() const;
+    Applet *sideBar() const;
+    Applet *workSpace() const;
+    Applet *detailView() const;
+
     virtual void loadState();
     virtual void saveState();
+
+    Q_SLOT void setSidebarState(int width, bool manualHide, bool autoHide);
+    Q_SIGNAL void sidebarStateChanged(int width, bool manualHide, bool autoHide);
 
 Q_SIGNALS:
     void aboutToOpen();
     void aboutToClose();
+
+    void titleBarInstallFinished();
+    void sideBarInstallFinished();
+    void workspaceInstallFinished();
+    void detailViewInstallFinished();
 
 private:
     Q_DECLARE_PRIVATE_D(dptr, Panel);

--- a/include/dfm-gui/quickutils.h
+++ b/include/dfm-gui/quickutils.h
@@ -29,6 +29,30 @@ public:
     };
     Q_ENUM(WidgetType)
 
+    /*!
+     * \brief 快捷键类型映射
+     *  注释为默认的快捷键组合
+     */
+    enum ShortcutType {
+        UnknownShortcut,
+        Refresh,   // F5
+        ActivateNextTab,   // ctrl + Tab
+        ActivatePreviousTab,   // ctrl + {shift + } BackTab
+        SearchCtrlF,   // ctrl + F
+        SearchCtrlL,   // ctrl + L
+        Back,   // ctrl  + Left
+        BackAlias,   // alt + Left
+        Forward,   // ctrl  + Right
+        ForwardAlias,   // alt + Right
+        CloseCurrentTab,   // ctrl + W
+        CreateTab,   // ctrl + T
+        CreateWindow,   // ctrl + N
+        TriggerActionByIndex,   // ctrl + [1, 8]
+        ActivateTabByIndex,   // alt + [1, 8]
+        ShowHotkeyHelp,   // ctrl + shift + ?
+    };
+    Q_ENUM(ShortcutType)
+
     explicit QuickUtils(QObject *parent = nullptr);
 };
 

--- a/include/dfm-gui/sharedqmlengine.h
+++ b/include/dfm-gui/sharedqmlengine.h
@@ -40,8 +40,8 @@ public:
 
 private:
     QScopedPointer<SharedQmlEnginePrivate> dptr;
-    Q_DECLARE_PRIVATE_D(dptr, SharedQmlEngine);
-    Q_DISABLE_COPY(SharedQmlEngine);
+    Q_DECLARE_PRIVATE_D(dptr, SharedQmlEngine)
+    Q_DISABLE_COPY(SharedQmlEngine)
 };
 
 DFMGUI_END_NAMESPACE

--- a/include/dfm-gui/shortcutmap.h
+++ b/include/dfm-gui/shortcutmap.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SHORTCUTMAP_H
+#define SHORTCUTMAP_H
+
+#include <dfm-gui/dfm_gui_global.h>
+#include <dfm-gui/quickutils.h>
+
+#include <QKeySequence>
+#include <QObject>
+
+class QKeyEvent;
+
+DFMGUI_BEGIN_NAMESPACE
+
+class ShortcutMapData;
+class ShortcutMap : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum SpecialType {
+        kType_Unknown = 0,   // 特殊快捷键类型，0 被视为未知类型
+    };
+
+    // 特殊键值，定义范围参考 Qt::Key
+    enum SpecialKey {
+        kKey_NumRange = 0x01111000,   // 映射 Qt::Key_1 ~ Qt::Key_8
+    };
+
+    // 按键绑定信息(后期按需添加 name / description 等属性)
+    struct KeyBinding
+    {
+        int type { kType_Unknown };   // 快捷键类型标记
+        QKeyCombination shortcutKeys;   // 快捷键设置
+
+        KeyBinding() = default;
+        KeyBinding(int t, const QKeyCombination &k)
+            : type(t), shortcutKeys(k) { }
+    };
+
+    explicit ShortcutMap(QObject *parent = nullptr);
+    ~ShortcutMap() override;
+
+    bool addShortcut(const KeyBinding &shortcut);
+    bool addShortcutList(const QList<KeyBinding> &shortcutList);
+
+    bool replaceShortcut(int type, const QKeyCombination &keys);
+    bool replaceShortcut(const KeyBinding &shortcut);
+    bool replaceShortcutList(const QList<KeyBinding> &shortcutList);
+
+    bool removeShortcut(int type);
+
+    int detectShortcut(QKeyEvent *keyEvent) const;
+
+private:
+    QScopedPointer<ShortcutMapData> d;
+    Q_DISABLE_COPY(ShortcutMap)
+};
+
+using ShortcutMapPtr = QSharedPointer<ShortcutMap>;
+
+DFMGUI_END_NAMESPACE
+
+#endif   // SHORTCUTMAP_H

--- a/src/dfm-framework/lifecycle/pluginmetaobject.cpp
+++ b/src/dfm-framework/lifecycle/pluginmetaobject.cpp
@@ -254,7 +254,11 @@ Q_CORE_EXPORT QDebug operator<<(QDebug out, const DPF_NAMESPACE::PluginQuickMeta
  */
 Q_CORE_EXPORT QDebug operator<<(QDebug out, const DPF_NAMESPACE::PluginQuickMetaPtr &quickMetaPtr)
 {
-    out << *quickMetaPtr;
+    if (quickMetaPtr) {
+        out << *quickMetaPtr;
+    } else {
+        out << "nullptr";
+    }
     return out;
 }
 

--- a/src/dfm-gui/attachedproperty.cpp
+++ b/src/dfm-gui/attachedproperty.cpp
@@ -44,8 +44,11 @@ ContainmentAttached::~ContainmentAttached() { }
 
 Containment *ContainmentAttached::qmlAttachedProperties(QObject *object)
 {
-    auto contain = qobject_cast<Containment *>(AppletAttached::qmlAttachedProperties(object));
-    return contain;
+    Applet *applet = AppletAttached::qmlAttachedProperties(object);
+    if (auto *contain = qobject_cast<Containment *>(applet))
+        return contain;
+
+    return applet->containment();
 }
 
 /*!
@@ -62,8 +65,11 @@ PanelAttached::~PanelAttached()
 
 Panel *PanelAttached::qmlAttachedProperties(QObject *object)
 {
-    auto panel = qobject_cast<Panel *>(AppletAttached::qmlAttachedProperties(object));
-    return panel;
+    Applet *applet = AppletAttached::qmlAttachedProperties(object);
+    if (auto *panel = qobject_cast<Panel *>(applet))
+        return panel;
+
+    return applet->panel();
 }
 
 DFMGUI_END_NAMESPACE

--- a/src/dfm-gui/containment_p.h
+++ b/src/dfm-gui/containment_p.h
@@ -20,6 +20,7 @@ public:
     explicit ContainmentPrivate(Containment *q);
 
     void setRootObject(QObject *item) override;
+    void appletRootObjectCreated(QObject *appletObject);
 
     QList<Applet *> applets;
 };

--- a/src/dfm-gui/containment_p.h
+++ b/src/dfm-gui/containment_p.h
@@ -22,7 +22,6 @@ public:
     void setRootObject(QObject *item) override;
 
     QList<Applet *> applets;
-    QPointer<QQuickWindow> window;
 };
 
 DFMGUI_END_NAMESPACE

--- a/src/dfm-gui/panel.cpp
+++ b/src/dfm-gui/panel.cpp
@@ -16,6 +16,18 @@ DFMBASE_USE_NAMESPACE
 
 DFMGUI_BEGIN_NAMESPACE
 
+static constexpr char kWindowManager[] { "WindowManager" };
+// Window config
+static constexpr char kWindowState[] { "WindowState" };
+static constexpr char kWidth[] = { "width" };
+static constexpr char kHeight[] = { "height" };
+static constexpr char kState[] = { "state" };
+// Sidebar config
+static constexpr char kSplitterState[] = { "SplitterState" };
+static constexpr char kSidebar[] = { "sidebar" };
+static constexpr char kManualHide[] = { "manualHide" };
+static constexpr char kAutoHide[] = { "autoHide" };
+
 enum NetWmState {
     kNetWmStateAbove = 0x1,
     kNetWmStateBelow = 0x2,
@@ -47,6 +59,77 @@ void PanelPrivate::setRootObject(QObject *item)
     ContainmentPrivate::setRootObject(item);
 }
 
+void PanelPrivate::loadWindowState()
+{
+    const QVariantMap &state = Application::appObtuselySetting()->value(kWindowManager, kWindowState).toMap();
+
+    int width = state.value(kWidth).toInt();
+    int height = state.value(kHeight).toInt();
+    NetWmStates windowState = static_cast<NetWmStates>(state.value(kState).toInt());
+
+    // fix bug 30932,获取全屏属性，必须是width全屏和height全屏属性都满足，才判断是全屏
+    if ((WindowManager::instance()->windowIdList().isEmpty())
+        && ((windowState & kNetWmStateMaximizedHorz) != 0 && (windowState & kNetWmStateMaximizedVert) != 0)) {
+        // make window to be maximized.
+        // the following calling is copyed from QWidget::showMaximized()
+        window->setWindowStates((window->windowStates() & ~(Qt::WindowMinimized | Qt::WindowFullScreen))
+                                | Qt::WindowMaximized);
+    } else {
+        window->resize(width, height);
+    }
+}
+
+void PanelPrivate::saveWindowState() const
+{
+    NetWmStates states { 0 };
+    if (WindowUtils::isWayLand()) {
+        if (window->windowStates().testFlag(Qt::WindowMaximized)) {
+            states = static_cast<NetWmState>(kNetWmStateMaximizedHorz | kNetWmStateMaximizedVert);
+        }
+    } else {
+        /// The power by dxcb platform plugin
+        states = static_cast<NetWmStates>(window->property("_d_netWmStates").toInt());
+    }
+
+    QVariantMap state;
+    // fix bug 30932,获取全屏属性，必须是width全屏和height全屏属性都满足，才判断是全屏
+    if ((states & kNetWmStateMaximizedHorz) == 0 || (states & kNetWmStateMaximizedVert) == 0) {
+        state[kWidth] = window->size().width();
+        state[kHeight] = window->size().height();
+    } else {
+        const QVariantMap &state1 = Application::appObtuselySetting()->value(kWindowManager, kWindowState).toMap();
+        state[kWidth] = state1.value(kWidth).toInt();
+        state[kHeight] = state1.value(kHeight).toInt();
+        state[kState] = static_cast<int>(states);
+    }
+    Application::appObtuselySetting()->setValue(kWindowManager, kWindowState, state);
+}
+
+/*!
+ * \return 从配置文件中取得侧边栏的宽度，仅在初始化时调用
+ */
+void PanelPrivate::loadSidebarState()
+{
+    const QVariantMap &state = Application::appObtuselySetting()->value(kWindowManager, kSplitterState).toMap();
+    leftWidth = state.value(kSidebar, PanelPrivate::kDefaultLeftWidth).toInt();
+    manualHideSidebar = state.value(kManualHide, false).toBool();
+    autoHideSidebar = state.value(kAutoHide, false).toBool();
+
+    Q_Q(Panel);
+    // 更新 qml 组件中的设置
+    q->setShowSidebar(!(manualHideSidebar || autoHideSidebar));
+    Q_EMIT q->sidebarStateChanged(leftWidth, manualHideSidebar, autoHideSidebar);
+}
+
+void PanelPrivate::saveSidebarState() const
+{
+    QVariantMap state;
+    state[kSidebar] = leftWidth;
+    state[kManualHide] = manualHideSidebar;
+    state[kAutoHide] = autoHideSidebar;
+    Application::appObtuselySetting()->setValue(kWindowManager, kSplitterState, state);
+}
+
 /*!
  * \class Panel
  * \brief 面板/窗体，用于弹出式的 QML 窗体
@@ -72,31 +155,79 @@ quint64 Panel::windId() const
     return d->window ? d->window->winId() : 0;
 }
 
+bool Panel::showSidebar() const
+{
+    return d_func()->showSidebar;
+}
+
+void Panel::setShowSidebar(bool b)
+{
+    Q_D(Panel);
+    if (d->showSidebar != b) {
+        d->showSidebar = b;
+        Q_EMIT showSidebarChanged(b);
+    }
+}
+
+/*!
+ * \brief 窗口关闭时会更新侧边栏的宽度和手动/自动隐藏状态，但仅在最后一个窗口关闭时触发保存
+ * \sa saveState()
+ */
+void Panel::setSidebarState(int width, bool manualHide, bool autoHide)
+{
+    Q_D(Panel);
+    d->leftWidth = width;
+    d->manualHideSidebar = manualHide;
+    d->autoHideSidebar = autoHide;
+}
+
+void Panel::installTitleBar(Applet *titlebar)
+{
+}
+
+void Panel::installSideBar(Applet *sidebar)
+{
+}
+
+void Panel::installWorkSpace(Applet *workspace)
+{
+}
+
+void Panel::installDetailView(Applet *detailview)
+{
+}
+
+Applet *Panel::titleBar() const
+{
+    return d_func()->titlebar;
+}
+
+Applet *Panel::sideBar() const
+{
+    return d_func()->sidebar;
+}
+
+Applet *Panel::workSpace() const
+{
+    return d_func()->workspace;
+}
+
+Applet *Panel::detailView() const
+{
+    return d_func()->detailview;
+}
+
 /*!
  * \brief 加载缓存配置的窗口设置，重载此函数自定义加载流程
  */
 void Panel::loadState()
 {
-    if (!window()) {
-        return;
-    }
+    Q_ASSERT_X(window(), "Init window state", "Window must exist when load state");
 
-    const QVariantMap &state = Application::appObtuselySetting()->value("WindowManager", "WindowState").toMap();
-
-    int width = state.value("width").toInt();
-    int height = state.value("height").toInt();
-    NetWmStates windowState = static_cast<NetWmStates>(state.value("state").toInt());
-
-    // fix bug 30932,获取全屏属性，必须是width全屏和height全屏属性都满足，才判断是全屏
-    if ((WindowManager::instance()->windowIdList().isEmpty())
-        && ((windowState & kNetWmStateMaximizedHorz) != 0 && (windowState & kNetWmStateMaximizedVert) != 0)) {
-        // make window to be maximized.
-        // the following calling is copyed from QWidget::showMaximized()
-        window()->setWindowStates((window()->windowStates() & ~(Qt::WindowMinimized | Qt::WindowFullScreen))
-                                  | Qt::WindowMaximized);
-    } else {
-        window()->resize(width, height);
-    }
+    Q_D(Panel);
+    d->loadWindowState();
+    // 设置窗口后再更新侧边栏
+    d->loadSidebarState();
 }
 
 /*!
@@ -104,32 +235,11 @@ void Panel::loadState()
  */
 void Panel::saveState()
 {
-    if (!window()) {
-        return;
-    }
+    Q_ASSERT_X(window(), "Init window state", "Window must exist when save state.");
 
-    NetWmStates states { 0 };
-    if (WindowUtils::isWayLand()) {
-        if (window()->windowStates().testFlag(Qt::WindowMaximized)) {
-            states = static_cast<NetWmState>(kNetWmStateMaximizedHorz | kNetWmStateMaximizedVert);
-        }
-    } else {
-        /// The power by dxcb platform plugin
-        states = static_cast<NetWmStates>(window()->property("_d_netWmStates").toInt());
-    }
-
-    QVariantMap state;
-    // fix bug 30932,获取全屏属性，必须是width全屏和height全屏属性都满足，才判断是全屏
-    if ((states & kNetWmStateMaximizedHorz) == 0 || (states & kNetWmStateMaximizedVert) == 0) {
-        state["width"] = window()->size().width();
-        state["height"] = window()->size().height();
-    } else {
-        const QVariantMap &state1 = Application::appObtuselySetting()->value("WindowManager", "WindowState").toMap();
-        state["width"] = state1.value("width").toInt();
-        state["height"] = state1.value("height").toInt();
-        state["state"] = static_cast<int>(states);
-    }
-    Application::appObtuselySetting()->setValue("WindowManager", "WindowState", state);
+    Q_D(Panel);
+    d->saveSidebarState();
+    d->saveWindowState();
 }
 
 DFMGUI_END_NAMESPACE

--- a/src/dfm-gui/panel_p.h
+++ b/src/dfm-gui/panel_p.h
@@ -6,6 +6,9 @@
 #define PANEL_P_H
 
 #include <dfm-gui/panel.h>
+#include <dfm-gui/appletitem.h>
+#include <dfm-gui/shortcutmap.h>
+
 #include "containment_p.h"
 
 DFMGUI_BEGIN_NAMESPACE
@@ -25,18 +28,23 @@ public:
     void loadSidebarState();
     void saveSidebarState() const;
 
+    bool handleKeyPressed(QKeyEvent *keyEvent);
+
+    static QSharedPointer<ShortcutMap> windowShortcut();
+
     QPointer<QQuickWindow> window;
+    AppletItem *sidebar { nullptr };
+    AppletItem *titlebar { nullptr };
+    AppletItem *workspace { nullptr };
+    AppletItem *detailview { nullptr };
+
     bool showSidebar { true };
-
-    Applet *sidebar;
-    Applet *titlebar;
-    Applet *workspace;
-    Applet *detailview;
-
     int leftWidth { 200 };
     bool autoHideSidebar { false };
     bool manualHideSidebar { false };
     static constexpr int kDefaultLeftWidth { 200 };
+
+    static ShortcutMapPtr shortcutPtr;
 };
 
 DFMGUI_END_NAMESPACE

--- a/src/dfm-gui/panel_p.h
+++ b/src/dfm-gui/panel_p.h
@@ -18,6 +18,25 @@ public:
     explicit PanelPrivate(Panel *q);
 
     void setRootObject(QObject *item) override;
+
+    void loadWindowState();
+    void saveWindowState() const;
+
+    void loadSidebarState();
+    void saveSidebarState() const;
+
+    QPointer<QQuickWindow> window;
+    bool showSidebar { true };
+
+    Applet *sidebar;
+    Applet *titlebar;
+    Applet *workspace;
+    Applet *detailview;
+
+    int leftWidth { 200 };
+    bool autoHideSidebar { false };
+    bool manualHideSidebar { false };
+    static constexpr int kDefaultLeftWidth { 200 };
 };
 
 DFMGUI_END_NAMESPACE

--- a/src/dfm-gui/shortcutmap.cpp
+++ b/src/dfm-gui/shortcutmap.cpp
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <dfm-gui/shortcutmap.h>
+
+#include <QKeyEvent>
+#include <QMultiMap>
+
+DFMGUI_BEGIN_NAMESPACE
+
+class ShortcutMapData
+{
+public:
+    ShortcutMapData() = default;
+    ~ShortcutMapData();
+
+    QMap<int, ShortcutMap::KeyBinding> shortcutMap;   // 映射<类型，按键绑定>
+    QMap<int, int> shortcutToType;   // 映射<快捷键，类型>
+};
+
+ShortcutMapData::~ShortcutMapData()
+{
+}
+
+/*!
+ * \class WindowShortcutMap
+ * \brief 用于窗口快捷映射设置和获取
+ *  一个动作可以对应多个快捷键，但快捷键对应的动作是唯一的，不能出现冲突。
+ *  kType_Unknown (0) 被视为未知的快捷类型
+ */
+ShortcutMap::ShortcutMap(QObject *parent)
+    : QObject { parent }, d { new ShortcutMapData }
+{
+}
+
+ShortcutMap::~ShortcutMap()
+{
+}
+
+/*!
+ * \brief 追加新的快捷键信息 \a shortcut
+ * \return 是否正常添加，若快捷键冲突，返回 false
+ */
+bool ShortcutMap::addShortcut(const KeyBinding &shortcut)
+{
+    int keys = shortcut.shortcutKeys.toCombined();
+    if (d->shortcutToType.contains(keys))
+        return false;
+
+    d->shortcutMap.insert(shortcut.type, shortcut);
+    d->shortcutToType.insert(keys, shortcut.type);
+    return true;
+}
+
+/*!
+ * \brief 追加新的快捷键信息 \a shortcutList
+ * \return 是否正常添加，若快捷键冲突，返回 false
+ */
+bool ShortcutMap::addShortcutList(const QList<KeyBinding> &shortcutList)
+{
+    for (const KeyBinding &bind : shortcutList) {
+        if (!addShortcut(bind))
+            return false;
+    }
+
+    return true;
+}
+
+/*!
+ * \brief 替换快捷键类型 \a type 的快捷键为 \a keys
+ * \return 是否正常替换，若快捷键冲突，返回 false
+ */
+bool ShortcutMap::replaceShortcut(int type, const QKeyCombination &keys)
+{
+    if (!d->shortcutMap.contains(type))
+        return false;
+
+    auto &bind = d->shortcutMap[type];
+    int oldShortcut = bind.shortcutKeys.toCombined();
+    int newShortcut = keys.toCombined();
+    if (oldShortcut != newShortcut) {
+        // 识别到快捷键冲突
+        if (d->shortcutToType.contains(newShortcut))
+            return false;
+
+        bind.shortcutKeys = keys;
+        d->shortcutToType.remove(oldShortcut);
+        d->shortcutToType.insert(newShortcut, bind.type);
+    }
+
+    return true;
+}
+
+/*!
+ * \brief 替换现有类型和 \a shortcut 一致的快捷键绑定
+ * \return 是否替换成功，若快捷键冲突，返回 false
+ */
+bool ShortcutMap::replaceShortcut(const KeyBinding &shortcut)
+{
+    return replaceShortcut(shortcut.type, shortcut.shortcutKeys);
+}
+
+/*!
+ * \brief 替换快捷键映射，缓存中相同类型的快捷键绑定会被替换为 \a shortcutList 中的快捷键设置
+ */
+bool ShortcutMap::replaceShortcutList(const QList<KeyBinding> &shortcutList)
+{
+    if (shortcutList.isEmpty())
+        return false;
+
+    for (const KeyBinding &bind : shortcutList) {
+        if (!replaceShortcut(bind.type, bind.shortcutKeys))
+            return false;
+    }
+
+    return true;
+}
+
+/*!
+ * \brief 移除快捷键类型为 \a type 的按键绑定
+ */
+bool ShortcutMap::removeShortcut(int type)
+{
+    if (!d->shortcutMap.contains(type))
+        return false;
+
+    KeyBinding bind = d->shortcutMap.take(type);
+    d->shortcutToType.remove(bind.shortcutKeys.toCombined());
+    return true;
+}
+
+/*!
+ * \brief 按键事件 \a keyEvent 是否匹配当前记录的按键绑定
+ * \return 是否检测到匹配的快捷键类型，未检测成功返回 kType_Unknown
+ */
+int ShortcutMap::detectShortcut(QKeyEvent *keyEvent) const
+{
+    if (keyEvent) {
+        const QKeyCombination combin = keyEvent->keyCombination();
+        const int key = combin.key();
+        if (Qt::Key_1 <= key && key <= Qt::Key_8) {
+            // 特殊处理：将特定区域的按键(Key_1 ~ Key_8)转换为 kKey_NumRange 处理
+            auto specialKey = QKeyCombination::fromCombined(combin.keyboardModifiers() | ShortcutMap::kKey_NumRange);
+            const int specialType = d->shortcutToType.value(specialKey.toCombined());
+            if (kType_Unknown != specialType) {
+                return specialType;
+            }
+        }
+
+        return d->shortcutToType.value(combin.toCombined());
+    }
+
+    return kType_Unknown;
+}
+
+DFMGUI_END_NAMESPACE

--- a/src/plugins/filemanager/qml/dfmplugin-core/FileWindow.qml
+++ b/src/plugins/filemanager/qml/dfmplugin-core/FileWindow.qml
@@ -7,11 +7,24 @@ import QtQml
 import QtQuick.Controls
 import QtQuick.Layouts
 import org.deepin.dtk
+import org.deepin.dtk.style 1.0 as DS
 import org.deepin.filemanager.gui
 import org.deepin.filemanager.declarative
 
 ApplicationWindow {
     id: root
+
+    // 布局Item
+    property alias detailview: detailviewProxy.target
+    // 右侧布局的内容的最小宽度，用于自动隐藏侧边栏
+    property real rightContentMinimumWidth: 600
+    property alias sidebar: sidebarProxy.target
+    property alias titlebar: titlebarProxy.target
+    property alias workspace: workspaceProxy.target
+
+    function adpatSidebarOnce() {
+        showSidebarAction.enabled = true;
+    }
 
     DWindow.enabled: true
     flags: Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
@@ -21,23 +34,23 @@ ApplicationWindow {
     width: 800
 
     // TODO: 待评估方案
-    Containment.onAppletRootObjectChanged: appletItem => {
+    Panel.onAppletRootObjectChanged: appletItem => {
         if (!appletItem) {
             return;
         }
         if (undefined !== appletItem.widgetType) {
             switch (appletItem.widgetType) {
             case QuickUtils.Sidebar:
-                sidebar.target = appletItem;
+                sidebar = appletItem;
                 break;
             case QuickUtils.Titlebar:
-                titlebar.target = appletItem;
+                titlebar = appletItem;
                 break;
             case QuickUtils.WorkSpace:
-                workspace.target = appletItem;
+                workspace = appletItem;
                 break;
             case QuickUtils.DetailSpace:
-                detailspace.target = appletItem;
+                detailview = appletItem;
                 break;
             default:
                 return;
@@ -47,22 +60,23 @@ ApplicationWindow {
             console.warn("Append invalid applet item", appletItem, appletItem.applet);
         }
     }
-
-    // For local module test
-    ActionMenu {
+    Panel.onSidebarStateChanged: (width, manualHide, autoHide) => {
+        spliter.target.visible = Panel.showSidebar;
+        spliter.setTargetWidth(width);
+        // 状态标识在界面完成更新后设置
+        spliter.manualHideSidebar = manualHide;
+        spliter.autoHideSidebar = autoHide;
     }
-    Connections {
-        function onWidthChanged(width) {
-        }
-
-        enabled: Window.window !== null
-        target: Window.window
+    onClosing: {
+        // 关闭前缓存当前侧边栏状态
+        Panel.setSidebarState(spliter.showWidth, spliter.manualHideSidebar, spliter.autoHideSidebar);
     }
+
     RowLayout {
         anchors.fill: parent
 
         Item {
-            id: sidebarProxy
+            id: leftContent
 
             Layout.preferredHeight: parent.height
 
@@ -71,46 +85,87 @@ ApplicationWindow {
 
                 anchors.fill: parent
 
-                // 用于同步标题栏高度占位的区块
-                Rectangle {
-                    id: titlebarCorner
-
-                    Layout.preferredHeight: titlebar.target ? titlebar.target.topHeaderHeight : titlebar.height
-                    Layout.preferredWidth: parent.width
-                    color: "lightyellow"
-                }
                 LayoutItemProxy {
-                    id: sidebar
+                    id: sidebarProxy
 
                     Layout.fillHeight: true
+                    // TODO 明确设计图后，高度属性移动到 QuickUtils 统一管理，不关联组件
+                    Layout.topMargin: DS.Style.titleBar.height
                 }
             }
             AnimationHSpliter {
                 id: spliter
 
-                enableAnimation: sidebar.target !== null
-                height: parent.height
-                target: sidebarProxy
+                // 自动隐藏侧边栏标识
+                property bool autoHideSidebar: false
+                property real constMaxWidth: 600
+                // 手动操作的隐藏侧边栏
+                property bool manualHideSidebar: false
 
-                // TODO 移动到 Sidebar, 通过事件处理，而不是 QML 隐式传输
-                Connections {
-                    function onSidebarVisibleNotify(bVisible) {
-                        spliter.switchShow = bVisible;
+                // 切换手动隐藏状态
+                function switchMaunualHide(bVisible) {
+                    if (transitionsRunning)
+                        return;
+                    manualHideSidebar = !bVisible;
+                    autoHideSidebar = false;
+
+                    // 特殊处理，当展开时窗口的大小过小时，会调整窗口大小
+                    if (expand) {
+                        if (showWidth > maximumWidth) {
+                            changeWindowWidth.to = root.width + showWidth - maximumWidth;
+                            changeWindowWidth.start();
+                        }
+                    }
+                }
+
+                enableAnimation: root.sidebar !== null
+                expand: Panel.showSidebar
+                height: parent.height
+                // 当前允许的宽度
+                maximumWidth: Math.min(root.width - root.rightContentMinimumWidth, constMaxWidth)
+                minimumWidth: 100
+                target: leftContent
+
+                onExpandChanged: {
+                    switchMaunualHide(expand);
+                }
+                onMaximumWidthChanged: {
+                    // 手动隐藏的状态优先
+                    if (manualHideSidebar) {
+                        return;
                     }
 
-                    enabled: titlebar.target !== null
-                    target: titlebar.target
+                    // 超过最小的显示范围，自动隐藏
+                    if (showWidth > maximumWidth) {
+                        Panel.showSidebar = false;
+                        // Note: 需要触发变更后更新状态
+                        autoHideSidebar = true;
+                        manualHideSidebar = false;
+                    } else if (autoHideSidebar) {
+                        Panel.showSidebar = true;
+                        autoHideSidebar = false;
+                    }
+                }
+
+                NumberAnimation {
+                    id: changeWindowWidth
+
+                    duration: 200
+                    easing.type: Easing.InOutQuad
+                    property: "width"
+                    target: root
                 }
             }
         }
         ColumnLayout {
+            id: rightContent
+
             Layout.fillHeight: true
             Layout.fillWidth: true
 
             LayoutItemProxy {
-                id: titlebar
+                id: titlebarProxy
 
-                onTargetChanged: target => {}
             }
             RowLayout {
                 Layout.fillHeight: true
@@ -118,11 +173,11 @@ ApplicationWindow {
                 spacing: 0
 
                 LayoutItemProxy {
-                    id: workspace
+                    id: workspaceProxy
 
                 }
                 LayoutItemProxy {
-                    id: detailspace
+                    id: detailviewProxy
 
                 }
             }

--- a/src/plugins/filemanager/qml/dfmplugin-detailspace/qml/DetailSpace.qml
+++ b/src/plugins/filemanager/qml/dfmplugin-detailspace/qml/DetailSpace.qml
@@ -60,8 +60,8 @@ ContainmentItem {
     AnimationHSpliter {
         enableAnimation: null !== Window.window
         enableMouse: true
+        expand: Containment.detailVisible
         leftSide: true
         showWidth: 300
-        switchShow: Containment.detailVisible
     }
 }

--- a/src/plugins/filemanager/qml/dfmplugin-titlebar/qml/Titlebar.qml
+++ b/src/plugins/filemanager/qml/dfmplugin-titlebar/qml/Titlebar.qml
@@ -135,11 +135,6 @@ ContainmentItem {
 
                         DTK.IconButton {
                             icon.name: "button_add"
-
-                            onClicked: {
-                                console.warn("--- test", Containment.applets);
-                                Applet.currentUrl = "file:///home/uos/Videos/dde-introduction.mp4";
-                            }
                         }
                     }
                 }

--- a/src/plugins/filemanager/qml/dfmplugin-titlebar/qml/Titlebar.qml
+++ b/src/plugins/filemanager/qml/dfmplugin-titlebar/qml/Titlebar.qml
@@ -14,40 +14,26 @@ ContainmentItem {
     id: titlebar
 
     property int breadcrumbsHeight: 30
-    // 是否显示侧边栏
-    property bool sidebarVisible: true
-    // 顶栏一层的高度
-    property alias topHeaderHeight: topHeader.height
     // 控件类型
     property int widgetType: QuickUtils.Titlebar
-
-    // TODO 移动到框架事件后移除
-    signal sidebarVisibleNotify(bool bVisible)
-
-    function updateTopLeftLayout() {
-        Qt.callLater(sidebarVisibleNotify, sidebarVisible);
-    }
 
     Layout.fillWidth: true
     implicitHeight: DS.Style.titleBar.height + breadcrumbsHeight
 
-    Component.onCompleted: {
-        updateTopLeftLayout();
-    }
     Window.onWindowChanged: {
         if (Window.window) {
             topLeftCorner.parent = Window.window.contentItem;
             topLeftCorner.x = 0;
             topLeftCorner.y = 0;
         }
-        updateTopLeftLayout();
-    }
-    onSidebarVisibleChanged: {
-        updateTopLeftLayout();
     }
 
+    // 左上角的
     Row {
         id: topLeftCorner
+
+        // 是否允许当前执行切换，进行动画时不允许
+        property bool enableSwitch: true
 
         height: DS.Style.titleBar.height
         leftPadding: 5
@@ -71,9 +57,7 @@ ContainmentItem {
             width: 36
 
             onClicked: {
-                if (!switchSidebar.running) {
-                    titlebar.sidebarVisible = !titlebar.sidebarVisible;
-                }
+                Panel.showSidebar = !Panel.showSidebar;
             }
 
             icon {
@@ -93,63 +77,71 @@ ContainmentItem {
 
             Layout.preferredHeight: DS.Style.titleBar.height
 
-            RowLayout {
-                Layout.fillHeight: true
-                Layout.leftMargin: sidebarVisible ? 0 : topLeftCorner.width
-                layoutDirection: Qt.LeftToRight
-
-                Behavior on Layout.leftMargin {
-                    NumberAnimation {
-                        id: switchSidebar
-
-                        duration: 200
-                        easing.type: Easing.InOutQuad
-                    }
-                }
-
-                DTK.IconButton {
-                    icon.name: "arrow_ordinary_left"
-                }
-
-                DTK.IconButton {
-                    icon.name: "arrow_ordinary_right"
-                }
-
-                TabBar {
-                    TabButton {
-                        text: qsTr("Home")
-                        width: implicitWidth
-                    }
-
-                    TabButton {
-                        text: qsTr("Discover")
-                        width: implicitWidth
-                    }
-
-                    TabButton {
-                        text: qsTr("Activity")
-                        width: implicitWidth
-                    }
-                }
-
-                DTK.IconButton {
-                    icon.name: "button_add"
-
-                    onClicked: {
-                        console.warn("--- test", Containment.applets);
-                        Applet.currentUrl = "file:///home/uos/Videos/dde-introduction.mp4";
-                    }
-                }
-            }
-
             Loader {
                 Layout.fillWidth: true
                 active: null !== Window.window
                 height: DS.Style.titleBar.height
 
+                // TODO: DTK.TitleBar 左侧有默认的间距，不过设计图间距较大，如可行就无需调整
                 sourceComponent: DTK.TitleBar {
                     title: ""
                     width: parent.width
+
+                    leftContent: RowLayout {
+                        layoutDirection: Qt.LeftToRight
+
+                        Item {
+                            // 需要 Titlebar Applet 已追加到 Panel 中
+                            Layout.leftMargin: Panel.showSidebar ? 0 : topLeftCorner.width
+
+                            Behavior on Layout.leftMargin {
+                                NumberAnimation {
+                                    id: switchSidebar
+
+                                    duration: 200
+                                    easing.type: Easing.InOutQuad
+
+                                    onRunningChanged: {
+                                        topLeftCorner.enableSwitch = !running;
+                                    }
+                                }
+                            }
+                        }
+
+                        DTK.IconButton {
+                            icon.name: "arrow_ordinary_left"
+                        }
+
+                        DTK.IconButton {
+                            icon.name: "arrow_ordinary_right"
+                        }
+
+                        TabBar {
+                            TabButton {
+                                text: qsTr("Home")
+                                width: implicitWidth
+                            }
+
+                            TabButton {
+                                text: qsTr("Discover")
+                                width: implicitWidth
+                            }
+
+                            TabButton {
+                                text: qsTr("Activity")
+                                width: implicitWidth
+                            }
+                        }
+
+                        DTK.IconButton {
+                            icon.name: "button_add"
+
+                            onClicked: {
+                                console.warn("--- test", Containment.applets);
+                                Applet.currentUrl = "file:///home/uos/Videos/dde-introduction.mp4";
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
* Refactor FileManagerWindow as Panel, restore titlebar state when restarting the app.
* Set appletitem parent when appending, auto destory the appletitem if CppOwnership.
* Adapt FileWindow interface, add shortcut key implementation.