### PR TITLE
feat: Process group expansion under grouping

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -116,6 +116,7 @@ enum ItemRoles {
     kItemIsGroupHeaderType = Qt::UserRole + 39,
     kItemGroupHeaderKey = Qt::UserRole + 40,
     kItemGroupDisplayIndex = Qt::UserRole + 41,
+    kItemGroupExpandedRole = Qt::UserRole + 42,
     kItemUnknowRole = Qt::UserRole + 999
 };
 

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupedmodeldata.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupedmodeldata.cpp
@@ -97,6 +97,7 @@ void GroupedModelData::rebuildFlattenedItems()
                 }
             }
         }
+        group.isExpanded = isExpanded;
         ++index;
     }
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/modelitemwrapper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/modelitemwrapper.cpp
@@ -90,6 +90,8 @@ QVariant ModelItemWrapper::getData(int role) const
             return groupData->groupKey;
         case Global::kItemGroupDisplayIndex:
             return groupData->displayInedx;
+        case Global::kItemGroupExpandedRole:
+            return groupData->isExpanded;
         default:
             break;
         }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -307,7 +307,7 @@ void BaseItemDelegate::paintGroupHeader(QPainter *painter, const QStyleOptionVie
 
     // Get expansion state - assume expanded by default for now
     // TODO: This should be retrieved from the model or worker
-    bool isExpanded = true;
+    bool isExpanded = index.data(Global::ItemRoles::kItemGroupExpandedRole).toBool();
 
     // Calculate layout rectangles
     QRect expandButtonRect = getExpandButtonRect(option);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
@@ -131,6 +131,8 @@ public:
     virtual QSize getGroupHeaderSizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
     virtual void paintGroupHeader(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
+    QRect getExpandButtonRect(const QStyleOptionViewItem &option) const;
+
 signals:
     void groupExpansionToggled(const QString &groupKey);
     void groupHeaderClicked(const QString &groupKey);
@@ -149,7 +151,7 @@ protected:
     void paintGroupText(QPainter *painter, const QRect &textRect, const QString &text, const QStyleOptionViewItem &option) const;
 
     // Group layout calculation methods
-    QRect getExpandButtonRect(const QStyleOptionViewItem &option) const;
+
     QRect getGroupTextRect(const QStyleOptionViewItem &option) const;
 
     QList<QRectF> getCornerGeometryList(const QRectF &baseRect, const QSizeF &cornerSize) const;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -246,10 +246,13 @@ private:
     bool cdUp();
     QModelIndex iconIndexAt(const QPoint &pos, const QSize &itemSize) const;
     bool expandOrCollapseItem(const QModelIndex &index, const QPoint &pos);
+    bool groupExpandOrCollapseItem(const QModelIndex &index, const QPoint &pos, const bool isArr = true);
 
     void recordSelectedUrls();
 
     void focusOnView();
+
+    bool isGroupHeader(const QModelIndex &index) const;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -917,24 +917,24 @@ int IconItemDelegate::getGroupHeaderHeight(const QStyleOptionViewItem &option) c
 
 bool IconItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index)
 {
-    // Handle group header clicks
-    if (isGroupHeaderItem(index) && event->type() == QEvent::MouseButtonPress) {
-        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-        handleGroupHeaderClick(mouseEvent, option, index);
-        return true;
-    }
+    // // Handle group header clicks
+    // if (isGroupHeaderItem(index) && event->type() == QEvent::MouseButtonPress) {
+    //     QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+    //     handleGroupHeaderClick(mouseEvent, option, index);
+    //     return true;
+    // }
 
-    // Handle double-click on group headers for expand/collapse
-    if (isGroupHeaderItem(index) && event->type() == QEvent::MouseButtonDblClick) {
-        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-        if (mouseEvent->button() == Qt::LeftButton) {
-            const QString groupKey = index.data(Global::kItemGroupHeaderKey).toString();
-            if (!groupKey.isEmpty()) {
-                emit const_cast<IconItemDelegate *>(this)->groupExpansionToggled(groupKey);
-            }
-            return true;
-        }
-    }
+    // // Handle double-click on group headers for expand/collapse
+    // if (isGroupHeaderItem(index) && event->type() == QEvent::MouseButtonDblClick) {
+    //     QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+    //     if (mouseEvent->button() == Qt::LeftButton) {
+    //         const QString groupKey = index.data(Global::kItemGroupHeaderKey).toString();
+    //         if (!groupKey.isEmpty()) {
+    //             emit const_cast<IconItemDelegate *>(this)->groupExpansionToggled(groupKey);
+    //         }
+    //         return true;
+    //     }
+    // }
 
     // Call base class implementation for regular items
     return BaseItemDelegate::editorEvent(event, model, option, index);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -769,24 +769,24 @@ int ListItemDelegate::getGroupHeaderHeight(const QStyleOptionViewItem &option) c
 bool ListItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index)
 {
     // Handle group header clicks
-    if (isGroupHeaderItem(index) && event->type() == QEvent::MouseButtonPress) {
-        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-        handleGroupHeaderClick(mouseEvent, option, index);
-        return true;
-    }
+    // if (isGroupHeaderItem(index) && event->type() == QEvent::MouseButtonPress) {
+    //     QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+    //     handleGroupHeaderClick(mouseEvent, option, index);
+    //     return true;
+    // }
 
     // Handle double-click on group headers for expand/collapse
-    if (isGroupHeaderItem(index) && event->type() == QEvent::MouseButtonDblClick) {
-        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-        if (mouseEvent->button() == Qt::LeftButton) {
-            // Extract group key from index
-            const QString groupKey = index.data(Global::kItemGroupHeaderKey).toString();
-            if (!groupKey.isEmpty()) {
-                emit const_cast<ListItemDelegate *>(this)->groupExpansionToggled(groupKey);
-            }
-            return true;
-        }
-    }
+    // if (isGroupHeaderItem(index) && event->type() == QEvent::MouseButtonDblClick) {
+    //     QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+    //     if (mouseEvent->button() == Qt::LeftButton) {
+    //         // Extract group key from index
+    //         const QString groupKey = index.data(Global::kItemGroupHeaderKey).toString();
+    //         if (!groupKey.isEmpty()) {
+    //             emit const_cast<ListItemDelegate *>(this)->groupExpansionToggled(groupKey);
+    //         }
+    //         return true;
+    //     }
+    // }
 
     // Call base class implementation for regular items
     return BaseItemDelegate::editorEvent(event, model, option, index);


### PR DESCRIPTION
1. Block the handling of editorevent events under the list and icon
2. Add kItemGroupExpandedRole to handle group expansion
3. Process the unfolding logic in the mousepressevent of Fileview
4. Move the arrow area for group retrieval to public
5. Add the processing logic for grouping doubleclicks

处理分组下的group展开
1.屏蔽list和icon下的editorevent事件中的处理
2.添加kItemGroupExpandedRole处理分组展开
3.在fileview的mousepressevent中处理展开逻辑
4.移动获取分组的箭头区域到public
5.添加分组doubleclick的处理逻辑

Log: Process group expansion under grouping