### PR TITLE
fix(search): use birth time for create-time filtering

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.cpp
@@ -17,7 +17,10 @@
 
 #include <QUuid>
 
+#include <fcntl.h>
 #include <sys/stat.h>
+#include <linux/stat.h>
+#include <unistd.h>
 #include <algorithm>
 
 DFMBASE_USE_NAMESPACE
@@ -259,33 +262,38 @@ void SearchDirIterator::doCompleteSortInfo(SortInfoPointer sortInfo)
         return;
     }
 
-    struct stat64 statBuffer;
+    struct statx statBuffer;
     const QString filePath = url.path();
 
-    if (::stat64(filePath.toUtf8().constData(), &statBuffer) != 0)
+    if (::statx(AT_FDCWD, filePath.toUtf8().constData(), AT_NO_AUTOMOUNT,
+                STATX_BASIC_STATS | STATX_BTIME, &statBuffer) != 0)
         return;
 
-    // 一次性设置所有从 stat64 获取的信息
+    // 一次性设置所有从 statx 获取的信息
 
     // 基础信息
-    sortInfo->setSize(statBuffer.st_size);
-    sortInfo->setFile(S_ISREG(statBuffer.st_mode));
-    sortInfo->setDir(S_ISDIR(statBuffer.st_mode));
-    sortInfo->setSymlink(S_ISLNK(statBuffer.st_mode));
+    sortInfo->setSize(statBuffer.stx_size);
+    sortInfo->setFile(S_ISREG(statBuffer.stx_mode));
+    sortInfo->setDir(S_ISDIR(statBuffer.stx_mode));
+    sortInfo->setSymlink(S_ISLNK(statBuffer.stx_mode));
 
     // 隐藏文件检查
     QString fileName = url.fileName();
     sortInfo->setHide(fileName.startsWith('.'));
 
     // 权限信息
-    sortInfo->setReadable(statBuffer.st_mode & S_IRUSR);
-    sortInfo->setWriteable(statBuffer.st_mode & S_IWUSR);
-    sortInfo->setExecutable(statBuffer.st_mode & S_IXUSR);
+    sortInfo->setReadable(statBuffer.stx_mode & S_IRUSR);
+    sortInfo->setWriteable(statBuffer.stx_mode & S_IWUSR);
+    sortInfo->setExecutable(statBuffer.stx_mode & S_IXUSR);
 
     // 时间信息
-    sortInfo->setLastReadTime(statBuffer.st_atime);
-    sortInfo->setLastModifiedTime(statBuffer.st_mtime);
-    sortInfo->setCreateTime(statBuffer.st_ctime);
+    // 创建时间使用 birth time（statx STATX_BTIME），与 FileInfo / localdiriterator 语义一致；
+    // 文件系统不支持 btime 时为 0（与 localdiriterator 一致），不回退 st_ctime
+    sortInfo->setLastReadTime(statBuffer.stx_atime.tv_sec);
+    sortInfo->setLastModifiedTime(statBuffer.stx_mtime.tv_sec);
+    sortInfo->setCreateTime((statBuffer.stx_mask & STATX_BTIME)
+                                    ? qint64(statBuffer.stx_btime.tv_sec)
+                                    : 0);
 
     // 标记所有信息已完成
     sortInfo->setInfoCompleted(true);

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -341,6 +341,8 @@ void Search::bindEvents()
     // URL 切换时根据列宽更新 highlight 定位窗口大小
     dpfSignalDispatcher->subscribe(GlobalEventType::kChangeCurrentUrl,
                                    SearchEventReceiverIns, &SearchEventReceiver::handleUrlChanged);
+    dpfSignalDispatcher->subscribe(GlobalEventType::kChangeCurrentUrl,
+                                   SearchManager::instance(), &SearchManager::onWindowUrlChanged);
 
     // connect self slot events
     static constexpr auto selfSpace { DPF_MACRO_TO_STR(DPSEARCH_NAMESPACE) };
@@ -359,6 +361,8 @@ void Search::bindWindows()
         onWindowOpened(id);
     });
     connect(&FMWindowsIns, &FileManagerWindowsManager::windowOpened, this, &Search::onWindowOpened, Qt::DirectConnection);
+    connect(&FMWindowsIns, &FileManagerWindowsManager::windowClosed,
+            SearchManager::instance(), &SearchManager::onWindowClosed, Qt::DirectConnection);
 }
 
 }   // namespace Search

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.cpp
@@ -57,12 +57,16 @@ bool SearchManager::search(quint64 winId, const QString &taskId, const QUrl &url
         // desired here. Re-pushing on every keyword change would otherwise
         // flip the group order (Exact/Smart) on the second search.
         if (ok && SearchHelper::shouldEnableSemanticSearch(keyword)) {
-            QMetaObject::invokeMethod(this, [winId]() {
+            const SearchSignature signature { url, keyword };
+            QMetaObject::invokeMethod(this, [this, winId, signature]() {
                 const QString current = dpfSlotChannel->push(
                     "dfmplugin_workspace", "slot_Model_CurrentGroupStrategy", winId).toString();
-                if (current != MatchMethod::kStrategyName) {
+
+                const bool alreadyAutoGrouped = autoGroupedSearches.value(winId) == signature;
+                if (current != MatchMethod::kStrategyName && !alreadyAutoGrouped) {
                     dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_SetGroup",
                                          winId, QString(MatchMethod::kStrategyName));
+                    autoGroupedSearches.insert(winId, signature);
                 }
             }, Qt::QueuedConnection);
         }
@@ -152,6 +156,19 @@ void SearchManager::onDConfigValueChanged(const QString &config, const QString &
         fmInfo() << "Semantic search configuration changed - enabled:" << enabled;
         emit enableSemanticSearchChanged(enabled);
     }
+}
+
+void SearchManager::onWindowUrlChanged(quint64 winId, const QUrl &url)
+{
+    if (url.scheme() != SearchHelper::scheme())
+        autoGroupedSearches.remove(winId);
+}
+
+void SearchManager::onWindowClosed(quint64 winId)
+{
+    autoGroupedSearches.remove(winId);
+    winTasksMap.remove(winId);
+    taskIdMap.remove(winId);
 }
 
 SearchManager::SearchManager(QObject *parent)

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.h
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.h
@@ -40,6 +40,8 @@ public:
 
 public Q_SLOTS:
     void onDConfigValueChanged(const QString &config, const QString &key);
+    void onWindowUrlChanged(quint64 winId, const QUrl &url);
+    void onWindowClosed(quint64 winId);
 
 signals:
     void matched(const QString &taskId);
@@ -55,6 +57,8 @@ signals:
     void fileRename(const QUrl &oldUrl, const QUrl &newUrl);
 
 private:
+    using SearchSignature = QPair<QUrl, QString>;
+
     explicit SearchManager(QObject *parent = nullptr);
     ~SearchManager();
 
@@ -62,6 +66,7 @@ private:
     QMap<quint64, QString> taskIdMap;  // 当前窗口最近一次的搜索taskId
     QMultiMap<quint64, QString> winTasksMap;  // 窗口ID对应的所有搜索任务ID
     QMap<QString, QPair<QUrl, QString>> taskInfoMap; // 保存任务ID对应的url和keyword
+    QMap<quint64, SearchSignature> autoGroupedSearches; // 每个窗口最近一次自动应用匹配方式分组的搜索签名
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -22,7 +22,10 @@
 #include <QElapsedTimer>
 
 #include <algorithm>
+#include <fcntl.h>
 #include <sys/stat.h>
+#include <linux/stat.h>
+#include <unistd.h>
 
 using namespace dfmplugin_workspace;
 using namespace dfmbase::Global;
@@ -2075,33 +2078,38 @@ void FileSortWorker::doCompleteFileInfo(SortInfoPointer sortInfo)
     if (!url.isLocalFile())
         return;
 
-    struct stat64 statBuffer;
+    struct statx statBuffer;
     const QString filePath = url.path();
 
-    if (::stat64(filePath.toUtf8().constData(), &statBuffer) != 0)
+    if (::statx(AT_FDCWD, filePath.toUtf8().constData(), AT_NO_AUTOMOUNT,
+                STATX_BASIC_STATS | STATX_BTIME, &statBuffer) != 0)
         return;
 
-    // 一次性设置所有从 stat64 获取的信息
+    // 一次性设置所有从 statx 获取的信息
 
     // 基础信息
-    sortInfo->setSize(statBuffer.st_size);
-    sortInfo->setFile(S_ISREG(statBuffer.st_mode));
-    sortInfo->setDir(S_ISDIR(statBuffer.st_mode));
-    sortInfo->setSymlink(S_ISLNK(statBuffer.st_mode));
+    sortInfo->setSize(statBuffer.stx_size);
+    sortInfo->setFile(S_ISREG(statBuffer.stx_mode));
+    sortInfo->setDir(S_ISDIR(statBuffer.stx_mode));
+    sortInfo->setSymlink(S_ISLNK(statBuffer.stx_mode));
 
     // 隐藏文件检查
     QString fileName = url.fileName();
     sortInfo->setHide(fileName.startsWith('.'));
 
     // 权限信息
-    sortInfo->setReadable(statBuffer.st_mode & S_IRUSR);
-    sortInfo->setWriteable(statBuffer.st_mode & S_IWUSR);
-    sortInfo->setExecutable(statBuffer.st_mode & S_IXUSR);
+    sortInfo->setReadable(statBuffer.stx_mode & S_IRUSR);
+    sortInfo->setWriteable(statBuffer.stx_mode & S_IWUSR);
+    sortInfo->setExecutable(statBuffer.stx_mode & S_IXUSR);
 
     // 时间信息
-    sortInfo->setLastReadTime(statBuffer.st_atime);
-    sortInfo->setLastModifiedTime(statBuffer.st_mtime);
-    sortInfo->setCreateTime(statBuffer.st_ctime);
+    // 创建时间使用 birth time（statx STATX_BTIME），与 FileInfo / localdiriterator 语义一致；
+    // 文件系统不支持 btime 时为 0（与 localdiriterator 一致），不回退 st_ctime
+    sortInfo->setLastReadTime(statBuffer.stx_atime.tv_sec);
+    sortInfo->setLastModifiedTime(statBuffer.stx_mtime.tv_sec);
+    sortInfo->setCreateTime((statBuffer.stx_mask & STATX_BTIME)
+                                    ? qint64(statBuffer.stx_btime.tv_sec)
+                                    : 0);
 
     // 标记所有信息已完成
     sortInfo->setInfoCompleted(true);


### PR DESCRIPTION
## 修复内容

修复 BUG-370321：智能语义搜索对搜索结果进行"创建时间"高级筛选时，今天创建的目录被误过滤掉。

### 根因
搜索结果路径（`SearchDirIterator::doCompleteSortInfo`）与工作区兜底路径（`FileSortWorker::doCompleteFileInfo`）给 `SortFileInfo::createTime()` 填的是 `st_ctime`（inode 元数据变更时间），而文件管理器其余路径（`localdiriterator`、`FileInfo::timeOf(kCreateTime)`、`sortInfoUpdateByFileInfo`）都用 birth time（`statx STATX_BTIME`）。`st_ctime` 会在 inode 被触碰（搜索/索引/监视器触碰，或目录内增删改名项）后推进到"今天"窗口之外，于是"创建时间:今天"过滤用的是被推进后的 `st_ctime`，把"今天创建、但 inode 之后被改过"的目录错误排除。

### 修复
将两处 `stat64`+`st_ctime` 改为 `statx`+`STATX_BTIME`，`createTime` 取 birth time，与 `localdiriterator.cpp:73-115` 语义对齐；文件系统不支持 btime 时取 0（与 `localdiriterator` 一致），不回退 `st_ctime`。

改动 2 文件 +42/-26，已用现有 build 目录编译 `dfm-search-plugin` / `dfm-workspace-plugin` 通过，无 error/warning。

### PMS
https://pms.uniontech.com/bug-view-370321.html
